### PR TITLE
Pinned pip openai install to 0.28 after openai.ChatCompletion change,…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask
-gunicorn
+Flask==2.3.2
+gunicorn==21.2.0
 openai==0.28


### PR DESCRIPTION
… which is no longer supported in openai>=1.0.0